### PR TITLE
Metadata for farjar

### DIFF
--- a/src/blade/fatjar.py
+++ b/src/blade/fatjar.py
@@ -56,7 +56,8 @@ def _manifest_scm(build_dir):
 def generate_fat_jar_metadata(jar, dependencies, conflicts):
     metadata_path = 'META-INF/blade'
     jar.writestr('%s/JAR.LIST' % metadata_path, '\n'.join(dependencies))
-    jar.writestr('%s/merge-info' % metadata_path, '\n'.join(conflicts))
+    content = ['[conflict]'] + conflicts
+    jar.writestr('%s/MERGE-INFO' % metadata_path, '\n'.join(content))
 
 
 def generate_fat_jar(target, jars):


### PR DESCRIPTION

  1. META-INF/blade/JAR.LIST for all the member jars aggregated

  2. META-INF/blade/merge-info for conflicting entries of jars:

    Path: targeting_id_allocation.xml
    From: build64_release/app/qzap/service/targeting/parser.jar
    Ignored: build64_release/app/qzap/service/targeting/analyzer.jar
