### PR TITLE
Support max link jobs in config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - "2.7"
 
 before_install: true
 

--- a/src/blade/blade_util.py
+++ b/src/blade/blade_util.py
@@ -64,7 +64,7 @@ def lock_file(filename):
         fcntl.fcntl(fd, fcntl.F_SETFD, old_fd_flags | fcntl.FD_CLOEXEC)
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         return fd, 0
-    except IOError, ex_value:
+    except IOError as ex_value:
         return -1, ex_value[0]
 
 

--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -453,11 +453,9 @@ class Blade(object):
             return user_jobs_num
 
         # Calculate job numbers smartly
-        jobs_num = 0
         distcc_enabled = config.get_item('distcc_config', 'enabled')
-
         if distcc_enabled and self.build_environment.distcc_env_prepared:
-            # Distcc cost doesn;t much local cpu, jobs can be quite large.
+            # Distcc doesn't cost much local cpu, jobs can be quite large.
             distcc_num = len(self.build_environment.get_distcc_hosts_list())
             jobs_num = min(max(int(1.5 * distcc_num), 1), 20)
         else:
@@ -465,10 +463,7 @@ class Blade(object):
             # machines with cpu_core_num > 4 is usually shared by multiple users,
             # set an upper bound to avoid interfering other users
             jobs_num = min(2 * cpu_core_num, 8)
-
-        if jobs_num != user_jobs_num:
-            console.info('tunes the parallel jobs number(-j N) to be %d' % (
-                jobs_num))
+        console.info('tunes the parallel jobs number(-j N) to be %d' % jobs_num)
         return jobs_num
 
     def get_all_rule_names(self):

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -69,6 +69,7 @@ class BladeConfig(object):
 
             'link_config': {
                 'link_on_tmp': False,
+                'link_jobs': None,
             },
 
             'java_config': {
@@ -404,7 +405,7 @@ def proto_library_config(append=None, **kwargs):
 @config_rule
 def protoc_plugin(**kwargs):
     """protoc_plugin. """
-    from proto_library_target import ProtocPlugin
+    from blade.proto_library_target import ProtocPlugin
     if 'name' not in kwargs:
         console.error_exit("Missing 'name' in protoc_plugin parameters: %s" % kwargs)
     section = _blade_config.get_section('protoc_plugin_config')


### PR DESCRIPTION
Building with distcc/icecream may specify a large -jN depending on the build cluster setup to speed up compilation, N might be 2 or 3 times of local cpu cores. In this case out of memory is likely to occur due to ~N link jobs launched simultaneous.