### PR TITLE
split ninja files

### DIFF
--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -430,13 +430,16 @@ class Blade(object):
             blade_object.ninja_rules()
             rules = blade_object.get_rules()
             if rules:
+                # Generate per-target ninja file
+                # TODO(chen3feng): Avoid regenerating ninja file when target is not changed.
                 target_dir = blade_object._target_file_path('')
                 if not os.path.exists(target_dir):
                     os.makedirs(target_dir)
-                subninja = blade_object._target_file_path('%s.ninja' % blade_object.name)
-                with open(subninja, 'w') as f:
+                target_ninja = blade_object._target_file_path('%s.ninja' % blade_object.name)
+                with open(target_ninja, 'w') as f:
                     f.writelines(rules)
-                rules_buf += 'include %s\n' % subninja
+                # Include it in the main file
+                rules_buf += 'include %s\n' % target_ninja
         return rules_buf
 
     def get_build_platform(self):

--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -430,7 +430,13 @@ class Blade(object):
             blade_object.ninja_rules()
             rules = blade_object.get_rules()
             if rules:
-                rules_buf += rules
+                target_dir = blade_object._target_file_path('')
+                if not os.path.exists(target_dir):
+                    os.makedirs(target_dir)
+                subninja = blade_object._target_file_path('%s.ninja' % blade_object.name)
+                with open(subninja, 'w') as f:
+                    f.writelines(rules)
+                rules_buf += 'include %s\n' % subninja
         return rules_buf
 
     def get_build_platform(self):

--- a/src/blade/build_manager.py
+++ b/src/blade/build_manager.py
@@ -438,7 +438,7 @@ class Blade(object):
                 target_ninja = blade_object._target_file_path('%s.ninja' % blade_object.name)
                 with open(target_ninja, 'w') as f:
                     f.writelines(rules)
-                # Include it in the main file
+                # Include it in the main ninja file
                 rules_buf += 'include %s\n' % target_ninja
         return rules_buf
 


### PR DESCRIPTION
Split build.ninja into multiple small ninja files, using `include` to join them together.
This change is to prepare optimizing per-target ninja file generation.