### PR TITLE
Fixed dirName with ~ in shell

### DIFF
--- a/install
+++ b/install
@@ -23,11 +23,11 @@ ln -sf $blade_dir/blade ~/bin
 echo ", Done."
 
 if ! echo $PATH | grep "$HOME/bin" &> /dev/null; then
-    profile='~/.bash_profile'
+    profile=~/.bash_profile
     if echo $SHELL | grep "zsh" &> /dev/null; then
-        profile='~.zshenv'
+        profile=~.zshenv
     elif [ -f ~/.profile ]; then
-        profile='~/.profile'
+        profile=~/.profile
     fi
     echo 'export PATH=~/bin:$PATH' >> $profile
     echo -e "\033[1;32mInstall success, please relogin or run 'source $profile' manually to apply\033[0m"


### PR DESCRIPTION
Syntax
~ Expand to the variable $HOME or home directory of the current user

Example
profile=~/.bash_profile
profile="$HOME/.bash_profile"