### PR TITLE
Update backend.py

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -37,10 +37,10 @@ from blade import util
 # NOTE the `$$` is required by ninja. and the `Multiple...` is the last and useless part of
 # the messages.
 _INCLUSION_STACK_SPLITTER = (r"awk '"
-    r"""/Multiple include guards may be useful for:/ {stop=1} """  # Can't exit here otherwise SIGPIPE maybe occurs.
-    r"""/^\.+ [^\/]/ { print $$0} """  # Non absolute path
-    r"""!/^\.+ / && !stop {print $$0 > "/dev/stderr"}"""  # Maybe error messages
-    r"'"
+     r"""/Multiple include guards may be useful for:/ {stop=1} """  # Can't exit here otherwise SIGPIPE maybe occurs.
+     r"""/^\.+ [^\/]/ && !stop { print $$0} """  # Non absolute path
+     r"""!/^\./ && !/^\// && !/Multiple include guards may be useful for:/ {print $$0 > "/dev/stderr"}"""  # Maybe error messages
+     r"'"
 )
 
 def _incs_list_to_string(incs):


### PR DESCRIPTION
with distcc on,  when err occerd, output of g++ -H is like
 .... ./proj/.../foo.h
.. /usr/.../bar.h
Multiple include guards may be useful for:
 .... ./proj/.../foo.h
.. /usr/.../bar.h

"gcc's err msg"
Multiple include guards may be useful for:
/usr/.../foo.h
... ./proj/.../bar.h