### PR TITLE
Add profile-guided optimization support

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -172,6 +172,26 @@ class _NinjaFileHeaderGenerator(object):
             cppflags.append('--coverage')
             linkflags.append('--coverage')
 
+        if hasattr(self.options, 'profile-generate') and not getattr(self.options, 'profile-generate') is None:
+            pgo_gen_dir = getattr(self.options, 'profile-generate')
+            if len(pgo_gen_dir) == 0:
+                cppflags.append('-fprofile-generate')
+                linkflags.append('-fprofile-generate')
+            else:
+                cppflags.append('-fprofile-generate=' + pgo_gen_dir)
+                linkflags.append('-fprofile-generate=' + pgo_gen_dir)
+            cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
+
+        if hasattr(self.options, 'profile-use') and not getattr(self.options, 'profile-use') is None:
+            pgo_use_dir = getattr(self.options, 'profile-use')
+            if len(pgo_use_dir) == 0:
+                cppflags.append('-fprofile-use')
+            else:
+                cppflags.append('-fprofile-use=' + pgo_use_dir)
+            cppflags.append('-fprofile-correction')
+            cppflags.append('-Wno-error=coverage-mismatch')
+            cppflags.append('-DPROFILE_GUIDED_OPTIMIZATION')
+
         cppflags = self.build_toolchain.filter_cc_flags(cppflags)
         return cppflags, linkflags
 

--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -174,7 +174,7 @@ class _NinjaFileHeaderGenerator(object):
 
         if hasattr(self.options, 'profile-generate') and not getattr(self.options, 'profile-generate') is None:
             pgo_gen_dir = getattr(self.options, 'profile-generate')
-            if len(pgo_gen_dir) == 0:
+            if not pgo_gen_dir:
                 cppflags.append('-fprofile-generate')
                 linkflags.append('-fprofile-generate')
             else:
@@ -184,7 +184,7 @@ class _NinjaFileHeaderGenerator(object):
 
         if hasattr(self.options, 'profile-use') and not getattr(self.options, 'profile-use') is None:
             pgo_use_dir = getattr(self.options, 'profile-use')
-            if len(pgo_use_dir) == 0:
+            if not pgo_use_dir:
                 cppflags.append('-fprofile-use')
             else:
                 cppflags.append('-fprofile-use=' + pgo_use_dir)

--- a/src/blade/command_line.py
+++ b/src/blade/command_line.py
@@ -266,6 +266,18 @@ class CommandLineParser(object):
             action='store_true', default=False,
             help=argparse.SUPPRESS)
 
+    def __add_pgo_arguments(self, parser):
+        """Add Profile-guided Optimization arguments."""
+        parser.add_argument(
+            '--profile-generate', dest='profile-generate', metavar='path',
+            action='store', type=str, nargs='?', const='',
+            help='Add build options to support profile-generate')
+
+        parser.add_argument(
+            '--profile-use', dest='profile-use', metavar='path',
+            action='store', type=str, nargs='?', const='',
+            help='Add build options to support profile-use')
+
     def _add_query_arguments(self, parser):
         """Add query arguments for parser."""
         self.__add_plat_profile_arguments(parser)
@@ -341,6 +353,7 @@ class CommandLineParser(object):
             self.__add_build_actions_arguments(parser)
             self.__add_generate_arguments(parser)
             self.__add_coverage_arguments(parser)
+            self.__add_pgo_arguments(parser)
 
     def _add_common_arguments(self, *parsers):
         for parser in parsers:


### PR DESCRIPTION
Add two profile-guided optimization realated command line arguments, '--profile-generate' and '--profile-use'. 
Please refer to the reference https://gcc.gnu.org/onlinedocs/gcc-10.1.0/gcc/Instrumentation-Options.html for details.