### PR TITLE
cc link puts target_linkflags into rspfile to resolve --whole-archive input exceed maximal length of bash

### DIFF
--- a/src/blade/backend.py
+++ b/src/blade/backend.py
@@ -333,17 +333,17 @@ class _NinjaFileHeaderGenerator(object):
         # Linking might have a lot of object files exceeding maximal length of a bash command line.
         # Using response file can resolve this problem.
         # Refer to: https://ninja-build.org/manual.html
-        link_args = '-o ${out} ${intrinsic_linkflags} ${linkflags} ${target_linkflags} @${out}.rsp ${extra_linkflags}'
+        link_args = '-o ${out} ${intrinsic_linkflags} ${linkflags} @${out}.rsp ${extra_linkflags}'
         self.generate_rule(name='link',
                            command=ld + ' ' + link_args,
                            rspfile='${out}.rsp',
-                           rspfile_content='${in}',
+                           rspfile_content='${target_linkflags} ${in}',
                            description='LINK BINARY ${out}',
                            pool=pool)
         self.generate_rule(name='solink',
                            command=ld + ' -shared ' + link_args,
                            rspfile='${out}.rsp',
-                           rspfile_content='${in}',
+                           rspfile_content='${target_linkflags} ${in}',
                            description='LINK SHARED ${out}',
                            pool=pool)
 

--- a/src/test/blade_test.py
+++ b/src/test/blade_test.py
@@ -130,7 +130,7 @@ class TargetTest(unittest.TestCase):
         self._assertCxxNoWarningFlags(cmdline)
 
     def assertLinkFlags(self, cmdline):
-        self.assertIn('-static-libgcc -static-libstdc++', cmdline)
+        self.assertNotIn('-static-libgcc -static-libstdc++', cmdline)
 
     def assertStaticLinkFlags(self, cmdline):
         self.assertNotIn('-shared', cmdline)

--- a/src/test/cc_binary_test.py
+++ b/src/test/cc_binary_test.py
@@ -33,8 +33,8 @@ class TestCcBinary(blade_test.TargetTest):
         self.assertCxxFlags(com_string_line)
 
         self.assertLinkFlags(string_main_depends_libs)
-        self.assertIn('liblowercase.a', string_main_depends_libs)
-        self.assertIn('libuppercase.a', string_main_depends_libs)
+        self.assertNotIn('liblowercase.a', string_main_depends_libs)
+        self.assertNotIn('libuppercase.a', string_main_depends_libs)
         self.assertTrue(self.findCommand(['Hello, world']))
 
 

--- a/src/test/cc_plugin_test.py
+++ b/src/test/cc_plugin_test.py
@@ -35,8 +35,8 @@ class TestCcPlugin(blade_test.TargetTest):
 
         self.assertDynamicLinkFlags(string_plugin_depends_libs)
         self.assertIn('-Wl,-Bsymbolic', string_plugin_depends_libs)
-        self.assertIn('liblowercase.a', string_plugin_depends_libs)
-        self.assertIn('libuppercase.a', string_plugin_depends_libs)
+        self.assertNotIn('liblowercase.a', string_plugin_depends_libs)
+        self.assertNotIn('libuppercase.a', string_plugin_depends_libs)
 
 
 if __name__ == '__main__':

--- a/src/test/cc_test_test.py
+++ b/src/test/cc_test_test.py
@@ -35,8 +35,8 @@ class TestCcTest(blade_test.TargetTest):
         self.assertCxxFlags(com_string_line)
 
         self.assertLinkFlags(string_main_depends_libs)
-        self.assertIn('liblowercase.a', string_main_depends_libs)
-        self.assertIn('libuppercase.a', string_main_depends_libs)
+        self.assertNotIn('liblowercase.a', string_main_depends_libs)
+        self.assertNotIn('libuppercase.a', string_main_depends_libs)
 
 
 if __name__ == '__main__':

--- a/src/test/test_target_test.py
+++ b/src/test/test_target_test.py
@@ -34,7 +34,7 @@ class TestTestRunner(blade_test.TargetTest):
         self.assertCxxFlags(com_string_line)
 
         self.assertLinkFlags(string_main_depends_libs)
-        self.assertIn('liblowercase.a', string_main_depends_libs)
+        self.assertNotIn('liblowercase.a', string_main_depends_libs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Based on [fix: exceed maximal length of bash when linking #927](https://github.com/chen3feng/blade-build/pull/927), put the target_linkflags parameters into rspfile

If the target depends on too many proto_library or use too many link_all_symbols on purpose, the --whole-archive may be too long to break the max length of bash single argument.

Ninja will start any command with /bin/sh -c "{command}". The command will act as a single argument in bash.

Query single argument max length: ```printf %d $((32 * $(getconf PAGE_SIZE) ))```