### PR TITLE
support enable warning when compiling pb.cc

### DIFF
--- a/doc/en/config.md
+++ b/doc/en/config.md
@@ -394,6 +394,7 @@ proto_library_config(
     protoc='protoc', #protoc compiler path
     protobuf_libs='//thirdparty/protobuf:protobuf', #protobuf library path, Blade deps format
     protobuf_path='thirdparty', # import proto search path, relative to BLADE_ROOT
+    protobuf_cc_warning='', # enable warning(disable -w) or not when compiling pb.cc, yes or no
     protobuf_include_path = 'thirdparty', # extra -I path when compiling pb.cc
 )
 ```

--- a/doc/zh_CN/config.md
+++ b/doc/zh_CN/config.md
@@ -378,6 +378,10 @@ Java 构建相关的配置：
 
   import 时的 proto 搜索路径，相对于 BLADE_ROOT。
 
+- `protobuf_cc_warning`: string = ''
+
+  编译pb.cc 时是否开启warnings, yes或者no
+
 - `protobuf_include_path` : string =
 
   编译 pb.cc 时额外的 -I 路径。

--- a/src/blade/config.py
+++ b/src/blade/config.py
@@ -230,6 +230,7 @@ class BladeConfig(object):
                 'protobuf_libs': [],
                 'protobuf_path': '',
                 'protobuf_incs': [],
+                'protobuf_cc_warning': '',
                 'protobuf_java_incs': [],
                 'protobuf_php_path': '',
                 'protoc_php_plugin': '',

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -100,6 +100,8 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         """
         # pylint: disable=too-many-locals
         srcs = var_to_list(srcs)
+        proto_config = config.get_section('proto_library_config')
+
         super(ProtoLibrary, self).__init__(
                 name=name,
                 type='proto_library',
@@ -108,7 +110,7 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
                 deps=deps,
                 visibility=visibility,
                 tags=tags,
-                warning='',
+                warning=proto_config['protobuf_cc_warning'],
                 defs=[],
                 incs=[],
                 export_incs=[],
@@ -123,7 +125,6 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
             self.attr['public_protos'] = [self._source_file_path(s) for s in srcs]
         self._add_tags('lang:proto', 'type:library')
 
-        proto_config = config.get_section('proto_library_config')
         protobuf_libs = var_to_list(proto_config['protobuf_libs'])
         protobuf_java_libs = var_to_list(proto_config['protobuf_java_libs'])
         protobuf_python_libs = var_to_list(proto_config['protobuf_python_libs'])

--- a/vim/syntax/blade_config.vim
+++ b/vim/syntax/blade_config.vim
@@ -139,6 +139,7 @@ syn keyword bladeArg fbthrift_incs
 syn keyword bladeTarget proto_library_config
 syn keyword bladeArg protobuf_go_path
 syn keyword bladeArg protobuf_incs
+syn keyword bladeArg protobuf_cc_warning
 syn keyword bladeArg protobuf_java_incs
 syn keyword bladeArg protobuf_java_libs
 syn keyword bladeArg protobuf_libs


### PR DESCRIPTION
Codegen plugins might generate some unsafe code in pb.cc. In some test scenarios, the warning option needs to be enabled.
