### PR TITLE
add gen_rule outputs into proto_library dependency

### DIFF
--- a/src/blade/gen_rule_target.py
+++ b/src/blade/gen_rule_target.py
@@ -74,6 +74,7 @@ class GenRuleTarget(Target):
         outs = [os.path.normpath(o) for o in outs]
 
         self.attr['outs'] = outs
+        self.attr['outputs'] = [self._target_file_path(o) for o in self.attr['outs']]
         self.attr['locations'] = []
         self.attr['cmd'] = LOCATION_RE.sub(self._process_location_reference, cmd)
         self.attr['cmd_name'] = cmd_name
@@ -167,7 +168,7 @@ class GenRuleTarget(Target):
         description = console.colored('%s %s' % (self.attr['cmd_name'], self.fullname), 'dimpurple')
         self._write_rule(_RULE_FORMAT % (rule, cmd, self.blade.get_root_dir(), description))
 
-        outputs = [self._target_file_path(o) for o in self.attr['outs']]
+        outputs = self.attr['outputs']
         inputs = self._expand_srcs()
         vars = {}
         if '${_in_1}' in cmd:

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -311,11 +311,16 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
             return self.data[key][:]
         self_protos = self.attr.get('public_protos')
         protos = self_protos[:] if len(self_protos) > 1 else []
+        genrule_outputs = []
         for key in self.deps:
             dep = self.target_database[key]
-            protos += dep.attr.get('public_protos', [])
+            public_protos = dep.attr.get('public_protos', [])
+            if len(public_protos) > 0:
+                protos += public_protos
+            if dep.type == 'gen_rule':
+                genrule_outputs += dep.attr.get('outputs', [])
         self.data[key] = protos
-        return protos[:]
+        return protos + genrule_outputs
 
     def _proto_descriptor_rules(self):
         inputs = [self._source_file_path(s) for s in self.srcs]

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -314,9 +314,7 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
         genrule_outputs = []
         for key in self.deps:
             dep = self.target_database[key]
-            public_protos = dep.attr.get('public_protos', [])
-            if len(public_protos) > 0:
-                protos += public_protos
+            protos += dep.attr.get('public_protos', [])
             if dep.type == 'gen_rule':
                 genrule_outputs += dep.attr.get('outputs', [])
         self.data[key] = protos

--- a/src/blade/proto_library_target.py
+++ b/src/blade/proto_library_target.py
@@ -306,9 +306,9 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
 
         # Including self's proto files because if there are multiple proto files in this target,
         # there may be import relationships between these files.
-        key = 'protoc_direct_dependencies'  # Cache the result
-        if key in self.data:
-            return self.data[key][:]
+        cache_key = 'protoc_direct_dependencies'  # Cache the result
+        if cache_key in self.data:
+            return self.data[cache_key][:]
         self_protos = self.attr.get('public_protos')
         protos = self_protos[:] if len(self_protos) > 1 else []
         genrule_outputs = []
@@ -317,8 +317,8 @@ class ProtoLibrary(CcTarget, java_targets.JavaTargetMixIn):
             protos += dep.attr.get('public_protos', [])
             if dep.type == 'gen_rule':
                 genrule_outputs += dep.attr.get('outputs', [])
-        self.data[key] = protos
-        return protos + genrule_outputs
+        self.data[cache_key] = protos + genrule_outputs
+        return self.data[cache_key][:]
 
     def _proto_descriptor_rules(self):
         inputs = [self._source_file_path(s) for s in self.srcs]


### PR DESCRIPTION
Proto_library can depends on gen_rule. By this rule, we want to add some config deps in proto_library by gen_rule. However,  when the gen_rule is built incrementally, the proto is not trigger to recompile.

By looking at the generated ninja file, the outs of gen_rule are not configured in the dependencies of the proto compilation command. 

Here I add gen_rule's outputs to proto's directory depdency to resolve this problem.

